### PR TITLE
Add actions-permissions test

### DIFF
--- a/.github/workflows/pr-auto-approve.yaml
+++ b/.github/workflows/pr-auto-approve.yaml
@@ -15,4 +15,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
       - uses: hmarr/auto-approve-action@v3


### PR DESCRIPTION
Add GitHub token permissions Monitor action test

This pull request adds a test for the GitHub token permissions Monitor action. The action is used to monitor the permissions of GitHub tokens and ensure that they are not over-permissive. The test ensures that the action is working as expected and that it is correctly configured.

Please review and merge this pull request if everything looks good.